### PR TITLE
Add GitHub workflows for clang-format and DCO checks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Git fills in the name and email from your `user.name` and `user.email` settings.
 - [Coding Guidelines](https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html)
 - [Style Guidelines](https://docs.zephyrproject.org/latest/contribute/style/index.html)
 
-The `.clang-format` at the repository root is copied from upstream Zephyr; running `clang-format` handles most formatting for you. Because clang-format's output can change between releases, please use version 21.1.8, which is the version we have agreed on.
+The `.clang-format` at the repository root is copied from upstream Zephyr; running `clang-format` handles most formatting for you. Because clang-format's output can change between releases, please use version 21.1.8, which is the version pinned in CI.
 
 ## Use of AI assistants in contributions
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Git fills in the name and email from your `user.name` and `user.email` settings.
 - [Coding Guidelines](https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html)
 - [Style Guidelines](https://docs.zephyrproject.org/latest/contribute/style/index.html)
 
-The `.clang-format` at the repository root is copied from upstream Zephyr; running `clang-format` handles most formatting for you. Because clang-format's output can change between releases, please use version 21.1.8, which is the version pinned in CI.
+The `.clang-format` at the repository root is copied from upstream Zephyr; running `clang-format` handles most formatting for you. Because clang-format's output can change between releases, please use version 22.1.5, which is the version pinned in CI.
 
 ## Use of AI assistants in contributions
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,30 @@
+name: clang-format
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - run: pip install clang-format==21.1.8
+
+      - env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" HEAD -- '*.c' '*.h')
+          for f in $files; do
+            clang-format --dry-run --Werror "$f" ||
+              echo "::warning file=$f::violation of coding style guidelines detected, please run clang-format"
+          done

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - run: pip install clang-format==21.1.8
+      - run: pip install clang-format==22.1.5
 
       - env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -22,9 +22,11 @@ jobs:
 
       - env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          files=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" HEAD -- '*.c' '*.h')
+          set -euo pipefail
+          files=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA"..."$HEAD_SHA" -- '*.c' '*.h')
           for f in $files; do
             clang-format --dry-run --Werror "$f" ||
-              echo "::warning file=$f::violation of coding style guidelines detected, please run clang-format"
+              echo "::warning file=$f::violation of coding style guidelines detected; please run clang-format"
           done

--- a/.github/workflows/developercertificate.yml
+++ b/.github/workflows/developercertificate.yml
@@ -1,0 +1,32 @@
+name: DCO
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          status=0
+          commits=$(git rev-list --no-merges "$BASE_SHA".."$HEAD_SHA")
+          for c in $commits; do
+            # Every commit must include a trailing "Signed-off-by: name <email>".
+            signoff=$(git show -s --format='%(trailers:key=Signed-off-by,valueonly)' "$c")
+            if ! grep -qE '^.+ <[^@>]+@[^@>]+>$' <<< "$signoff"; then
+              echo "::error::commit ${c:0:7} is not signed off; please affirm the DCO"
+              status=1
+            fi
+          done
+          exit $status


### PR DESCRIPTION
This PR adds two workflows: one verifying compliance with the coding style guidelines, the other checking that contributors affirm the DCO. Both are invoked on pull requests.

- The `clang-format.yml` workflow runs clang-format (v21.1.8) on all C source/header files touched by the PR and emits a warning annotation for each file that does not comply with the coding style guidelines. This workflow is advisory only and never blocks merging.
- The `developercertificate.yml` workflow checks that every non-merge commit in the PR includes a trailing `Signed-off-by: name <email>` line. If any commit is missing the DCO sign-off, the check fails and blocks merging.